### PR TITLE
Serialize failing on recursive calls

### DIFF
--- a/lib/mailchimp/helpers.js
+++ b/lib/mailchimp/helpers.js
@@ -5,7 +5,7 @@
  * @param key Key to encode (not required for top-level objects)
  * @return Encoded object
  */
-module.exports.serialize = function (value, key) {
+var serialize = module.exports.serialize = function (value, key) {
     
 	var output;
     key || (key = '');


### PR DESCRIPTION
The serialize function used by STS calls itself recursively and was failing.  Fixed by assigning the function to a local variable named `serialize` (in addition to `module.exports.serialize`).
