### PR TITLE
custom user-agent string

### DIFF
--- a/lib/mailchimp/MailChimpAPI_v1_1.js
+++ b/lib/mailchimp/MailChimpAPI_v1_1.js
@@ -22,6 +22,7 @@ function MailChimpAPI_v1_1 (apiKey, options) {
 	this.datacenter  = this.datacenter[1];
 	this.httpHost    = this.datacenter+'.api.mailchimp.com';
 	this.httpUri     = (this.secure) ? 'https://'+this.httpHost+':443' : 'http://'+this.httpHost+':80'; 
+	this.userAgent   = options.userAgent || '';
 	
 }
 
@@ -51,7 +52,7 @@ MailChimpAPI_v1_1.prototype.execute = function (method, availableParams, givenPa
 	request({
 		uri : this.httpUri+'/'+this.version+'/?output=json&method='+method,
 		method: 'POST',
-		headers : { 'User-Agent' : 'node-mailchimp/'+this.packageInfo['version'] },
+		headers : { 'User-Agent' : this.userAgent+':node-mailchimp/'+this.packageInfo['version'] },
 		body : JSON.stringify(finalParams)
 	}, function (error, response, body) {
 		var parsedResponse;

--- a/lib/mailchimp/MailChimpAPI_v1_2.js
+++ b/lib/mailchimp/MailChimpAPI_v1_2.js
@@ -22,6 +22,7 @@ function MailChimpAPI_v1_2 (apiKey, options) {
 	this.datacenter  = this.datacenter[1];
 	this.httpHost    = this.datacenter+'.api.mailchimp.com';
 	this.httpUri     = (this.secure) ? 'https://'+this.httpHost+':443' : 'http://'+this.httpHost+':80'; 
+	this.userAgent   = options.userAgent || '';
 	
 }
 
@@ -51,7 +52,7 @@ MailChimpAPI_v1_2.prototype.execute = function (method, availableParams, givenPa
 	request({
 		uri : this.httpUri+'/'+this.version+'/?output=json&method='+method,
 		method: 'POST',
-		headers : { 'User-Agent' : 'node-mailchimp/'+this.packageInfo['version'] },
+		headers : { 'User-Agent' : this.userAgent+':node-mailchimp/'+this.packageInfo['version'] },
 		body : JSON.stringify(finalParams)
 	}, function (error, response, body) {
 		var parsedResponse;

--- a/lib/mailchimp/MailChimpAPI_v1_3.js
+++ b/lib/mailchimp/MailChimpAPI_v1_3.js
@@ -22,6 +22,7 @@ function MailChimpAPI_v1_3 (apiKey, options) {
 	this.datacenter  = this.datacenter[1];
 	this.httpHost    = this.datacenter+'.api.mailchimp.com';
 	this.httpUri     = (this.secure) ? 'https://'+this.httpHost+':443' : 'http://'+this.httpHost+':80'; 
+	this.userAgent   = options.userAgent || '';
 	
 }
 
@@ -51,7 +52,7 @@ MailChimpAPI_v1_3.prototype.execute = function (method, availableParams, givenPa
 	request({
 		uri : this.httpUri+'/'+this.version+'/?method='+method,
 		method: 'POST',
-		headers : { 'User-Agent' : 'node-mailchimp/'+this.packageInfo['version'] },
+		headers : { 'User-Agent' : this.userAgent+':node-mailchimp/'+this.packageInfo['version'] },
 		body : JSON.stringify(finalParams)
 	}, function (error, response, body) {
 		var parsedResponse;

--- a/lib/mailchimp/MailChimpExportAPI_v1_0.js
+++ b/lib/mailchimp/MailChimpExportAPI_v1_0.js
@@ -24,6 +24,7 @@ function MailChimpExportAPI_v1_0 (apiKey, options) {
 	this.datacenter  = this.datacenter[1];
 	this.httpHost    = this.datacenter+'.api.mailchimp.com';
 	this.httpUri     = (this.secure) ? 'https://'+this.httpHost+':443' : 'http://'+this.httpHost+':80';
+	this.userAgent   = options.userAgent || '';
 	
 }
 
@@ -56,7 +57,7 @@ MailChimpExportAPI_v1_0.prototype.execute = function (method, availableParams, g
 
 	request({
 		uri : this.httpUri+'/export/'+this.version+'/'+method+'/?'+query,
-		headers : { 'User-Agent' : 'node-mailchimp/'+this.packageInfo['version'] }
+		headers : { 'User-Agent' : this.userAgent+':node-mailchimp/'+this.packageInfo['version'] }
 	}, function (error, response, body) {
 		if (error) {
 			callback({ 'error' : 'Unable to connect to the MailChimp API endpoint.', 'code' : 'xxx' });

--- a/lib/mailchimp/MailChimpSTSAPI_v1_0.js
+++ b/lib/mailchimp/MailChimpSTSAPI_v1_0.js
@@ -24,6 +24,7 @@ function MailChimpSTSAPI_v1_0 (apiKey, options) {
 	this.datacenter  = this.datacenter[1];
 	this.httpHost    = this.datacenter+'.sts.mailchimp.com';
 	this.httpUri     = (this.secure) ? 'https://'+this.httpHost+':443' : 'http://'+this.httpHost+':80'; 
+	this.userAgent   = options.userAgent || '';
 	
 }
 
@@ -57,7 +58,7 @@ MailChimpSTSAPI_v1_0.prototype.execute = function (method, availableParams, give
 		method: 'POST',
 		headers : { 
                       'Content-Type': 'application/x-www-form-urlencoded',
-                      'User-Agent' : 'node-mailchimp/'+this.packageInfo['version'] 
+                      'User-Agent' : this.userAgent+':node-mailchimp/'+this.packageInfo['version'] 
                   },
         body : finalParams.join('&')
 	}, function (error, response, body) {


### PR DESCRIPTION
I just remembered reading in the API group discussion somewhere that MC would prefer it if we added app/implementation-specific useragent data to requests. (probably so it it is more clear in the API logs)

Totally optional, but it wouldn't hurt to have the capability.
