### PR TITLE
Fix for Export API campaignSubscriberActivity throw

### DIFF
--- a/lib/mailchimp/MailChimpExportAPI_v1_0.js
+++ b/lib/mailchimp/MailChimpExportAPI_v1_0.js
@@ -137,7 +137,13 @@ MailChimpExportAPI_v1_0.prototype.campaignSubscriberActivity = function (params,
  * it to the callback function.
  */
 MailChimpExportAPI_v1_0.prototype.campaignSubscriberActivityProcess = function (data, callback) {
-	
+
+  // when api returns empty set data variable is undefined
+  if(typeof data === 'undefined'){
+    callback(null, []);
+    return;
+  }
+
 	var resultStrings = data.split("\n");
 	var resultJSON    = [];
 	


### PR DESCRIPTION
If there is no subscriber activity for a campaign the campaignSubscriberActivityProcess method will receive an undefined data object, causing data.split to throw.  This patch detects this case and returns an empty array to the caller.
