### PR TITLE
Encode request body for MailChimp API 1.3 requests

### DIFF
--- a/lib/mailchimp/MailChimpAPI_v1_3.js
+++ b/lib/mailchimp/MailChimpAPI_v1_3.js
@@ -55,7 +55,7 @@ MailChimpAPI_v1_3.prototype.execute = function (method, availableParams, givenPa
 		uri : this.httpUri+'/'+this.version+'/?method='+method,
 		method: 'POST',
 		headers : { 'User-Agent' : this.userAgent+'node-mailchimp/'+this.packageInfo['version'] },
-		body : JSON.stringify(finalParams)
+		body : encodeURIComponent(JSON.stringify(finalParams))
 	}, function (error, response, body) {
 		var parsedResponse;
 		if (error) {


### PR DESCRIPTION
According to MailChimp in this thread:

https://groups.google.com/forum/?fromgroups=#!topic/mailchimp-api-discuss/3Po1CDGMqJA

it sounds like they're expecting all JSON request bodies be URL-encoded.  This change has allowed us to successfully subscribe email addresses with "+" characters.  I'm not sure what the other implications are as I'm only familiar with a small subset of the MailChimp API (and node-mailchimp).
