### PR TITLE
More detailed error msg when not able to connect to MailChimp API endpoint

### DIFF
--- a/lib/mailchimp/MailChimpAPI_v2_0.js
+++ b/lib/mailchimp/MailChimpAPI_v2_0.js
@@ -58,7 +58,7 @@ MailChimpAPI_v2_0.prototype.execute = function (method, availableParams, givenPa
 	}, function (error, response, body) {
 		var parsedResponse;
 		if (error) {
-			callback(new Error('Unable to connect to the MailChimp API endpoint.'));
+			callback(new Error('Unable to connect to the MailChimp API endpoint because ' + error.message));
 		} else {
 
 			try {


### PR DESCRIPTION
Hey,

I had this error with Mailchimp: Unable to connect to the MailChimp API endpoint.

Then I googled it but I found (almost) nothing. With this patch I get: Unable to connect to the MailChimp API endpoint because Hostname/IP doesn't match certificate's altnames

...which points me to thousands of websites about how to solve TLS problems with node ;)

Cheers, Philip