### PR TITLE
Add proxy option to MailchimpAPI

### DIFF
--- a/lib/mailchimp/MailChimpAPI_v1_1.js
+++ b/lib/mailchimp/MailChimpAPI_v1_1.js
@@ -24,6 +24,7 @@ function MailChimpAPI_v1_1 (apiKey, options) {
 	this.httpHost    = this.datacenter+'.api.mailchimp.com';
 	this.httpUri     = (this.secure) ? 'https://'+this.httpHost+':443' : 'http://'+this.httpHost+':80';
 	this.userAgent   = options.userAgent+' ' || '';
+	this.proxy       = options.proxy;
 
 }
 
@@ -55,7 +56,8 @@ MailChimpAPI_v1_1.prototype.execute = function (method, availableParams, givenPa
 		uri : this.httpUri+'/'+this.version+'/?output=json&method='+method,
 		method: 'POST',
 		headers : { 'User-Agent' : this.userAgent+'node-mailchimp/'+this.packageInfo['version'] },
-		body : encodeURIComponent(JSON.stringify(finalParams))
+		body : encodeURIComponent(JSON.stringify(finalParams)),
+		proxy : this.proxy,
 	}, function (error, response, body) {
 		helpers.handleMailChimpResponse(error, response, body, callback);
 	});

--- a/lib/mailchimp/MailChimpAPI_v1_2.js
+++ b/lib/mailchimp/MailChimpAPI_v1_2.js
@@ -24,6 +24,7 @@ function MailChimpAPI_v1_2 (apiKey, options) {
 	this.httpHost    = this.datacenter+'.api.mailchimp.com';
 	this.httpUri     = (this.secure) ? 'https://'+this.httpHost+':443' : 'http://'+this.httpHost+':80';
 	this.userAgent   = options.userAgent+' ' || '';
+	this.proxy       = options.proxy;
 
 }
 
@@ -55,7 +56,8 @@ MailChimpAPI_v1_2.prototype.execute = function (method, availableParams, givenPa
 		uri : this.httpUri+'/'+this.version+'/?output=json&method='+method,
 		method: 'POST',
 		headers : { 'User-Agent' : this.userAgent+'node-mailchimp/'+this.packageInfo['version'] },
-		body : encodeURIComponent(JSON.stringify(finalParams))
+		body : encodeURIComponent(JSON.stringify(finalParams)),
+		proxy : this.proxy,
 	}, function (error, response, body) {
 		helpers.handleMailChimpResponse(error, response, body, callback);
 	});

--- a/lib/mailchimp/MailChimpAPI_v1_3.js
+++ b/lib/mailchimp/MailChimpAPI_v1_3.js
@@ -24,6 +24,7 @@ function MailChimpAPI_v1_3 (apiKey, options) {
 	this.httpHost    = this.datacenter+'.api.mailchimp.com';
 	this.httpUri     = (this.secure) ? 'https://'+this.httpHost+':443' : 'http://'+this.httpHost+':80';
 	this.userAgent   = options.userAgent+' ' || '';
+	this.proxy       = options.proxy;
 
 }
 
@@ -55,7 +56,8 @@ MailChimpAPI_v1_3.prototype.execute = function (method, availableParams, givenPa
 		uri : this.httpUri+'/'+this.version+'/?method='+method,
 		method: 'POST',
 		headers : { 'User-Agent' : this.userAgent+'node-mailchimp/'+this.packageInfo['version'] },
-		body : encodeURIComponent(JSON.stringify(finalParams))
+		body : encodeURIComponent(JSON.stringify(finalParams)),
+		proxy : this.proxy,
 	}, function (error, response, body) {
 		helpers.handleMailChimpResponse(error, response, body, callback);
 	});

--- a/lib/mailchimp/MailChimpAPI_v2_0.js
+++ b/lib/mailchimp/MailChimpAPI_v2_0.js
@@ -22,6 +22,7 @@ function MailChimpAPI_v2_0 (apiKey, options) {
 	this.httpHost    = this.datacenter+'.api.mailchimp.com';
 	this.httpUri     = 'https://'+this.httpHost+':443';
 	this.userAgent   = options.userAgent+' ' || '';
+	this.proxy       = options.proxy;
 
 }
 
@@ -54,7 +55,8 @@ MailChimpAPI_v2_0.prototype.execute = function (method, availableParams, givenPa
 		method: 'POST',
 		headers : { 'User-Agent' : this.userAgent+'node-mailchimp/'+this.packageInfo.version, "accept-encoding" : "gzip,deflate" },
 		gzip: true,
-		body : JSON.stringify(finalParams)
+		body : JSON.stringify(finalParams),
+		proxy : this.proxy,
 	}, function (error, response, body) {
 		helpers.handleMailChimpResponse(error, response, body, callback);
 	});


### PR DESCRIPTION
Provides a way to use a static IP for Mailchimp on services which allocate one dynamically. This should prevent inadvertently exceeding the API rate limits on a shared IP.